### PR TITLE
Fixed increasing asteroid spawn rates upon clicking the "play again" button

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ document.addEventListener("DOMContentLoaded", function() {
     quitBtn.addEventListener("click", quitGame);
 
     function startGame() {
+        clearInterval(gameInterval);
         resetGame();
         interfaceDiv.style.display = "none";
         gameContainer.style.display = "block";
@@ -40,7 +41,6 @@ document.addEventListener("DOMContentLoaded", function() {
     }
     
     function endGame() {
-        clearInterval(gameInterval);
         gameContainer.style.display = "none";
         finalScore.textContent = score;
         endScreen.classList.remove("hidden");


### PR DESCRIPTION
The problem was that you were clearing the game interval in the 'endGame' function. This issue arises because each time we click on 'play again' button, a new click event listener gets created. It is because dom event listeners like click are asynchronous in nature. [More about it can be read here](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Introducing#event_handlers). So what basically is happening is that Each time the game is started by clicking the "play again" button, new click event listeners are added to the "play again" button without removing the previous ones which is leading to issue of creating multiple game intervals which are running simultaniously causing the increasing number of astroids. 

The fix is to reset the game interval everytime 'startGame' function gets called. This will ensure that before setting a new interval for asteroid creation, any previously set intervals are cleared